### PR TITLE
LibGDX width/height & ReshapeEvent

### DIFF
--- a/modules/libgdx/kotlin/com/huskerdev/openglfx/libgdx/LibGDXCanvas.kt
+++ b/modules/libgdx/kotlin/com/huskerdev/openglfx/libgdx/LibGDXCanvas.kt
@@ -40,6 +40,11 @@ class LibGDXCanvas(
         adapter.render()
     }
 
+    override fun fireReshapeEvent(width: Int, height: Int) {
+        super.fireReshapeEvent(width, height)
+        adapter.resize(width, height)
+    }
+
     override fun fireInitEvent() {
         if(!::application.isInitialized) {
             application = OGLFXApplication(configuration, this)

--- a/modules/libgdx/kotlin/com/huskerdev/openglfx/libgdx/internal/OGLFXGraphics.kt
+++ b/modules/libgdx/kotlin/com/huskerdev/openglfx/libgdx/internal/OGLFXGraphics.kt
@@ -46,8 +46,8 @@ class OGLFXGraphics(val canvas: GLCanvas): AbstractGraphics() {
     override fun setGL31(gl31: GL31?) { this.gl31 = gl31 }
     override fun setGL32(gl32: GL32?) { this.gl32 = gl32 }
 
-    override fun getWidth() = canvas.scaledWidth
-    override fun getHeight() = canvas.scaledHeight
+    override fun getWidth() = canvas.width.toInt()
+    override fun getHeight() = canvas.height.toInt()
     override fun getBackBufferWidth() = canvas.scaledWidth
     override fun getBackBufferHeight() = canvas.scaledHeight
 


### PR DESCRIPTION
This will add the missing ReshapeEvent to LibGDXCanvas and will use the unscaled width/height for getWidth and getHeight.