### PR TITLE
Fixes some bugs in IOSurface 

### DIFF
--- a/modules/core/kotlin/com/huskerdev/openglfx/GLExecutor.kt
+++ b/modules/core/kotlin/com/huskerdev/openglfx/GLExecutor.kt
@@ -39,6 +39,9 @@ internal const val GL_TRIANGLE_STRIP = 0x0005
 internal const val GL_COMPILE_STATUS = 0x8B81
 internal const val GL_TEXTURE_BINDING_2D = 0x8069
 internal const val GL_SCISSOR_TEST = 0xc11
+internal const val GL_ACTIVE_TEXTURE = 34016;
+internal const val GL_TEXTURE0 = 33984
+
 
 @Suppress("unused")
 open class GLExecutor {
@@ -49,6 +52,7 @@ open class GLExecutor {
         private var isInitialized = false
         @JvmStatic external fun nInitGLFunctions()
 
+        @JvmStatic external fun glActiveTexture(unit: Int)
         @JvmStatic external fun glEnable(cap: Int)
         @JvmStatic external fun glDisable(cap: Int)
         @JvmStatic external fun glDeleteFramebuffers(fbo: Int)

--- a/modules/core/kotlin/com/huskerdev/openglfx/internal/GLFXUtils.kt
+++ b/modules/core/kotlin/com/huskerdev/openglfx/internal/GLFXUtils.kt
@@ -1,9 +1,9 @@
 package com.huskerdev.openglfx.internal
 
 import com.huskerdev.grapl.core.platform.Platform
+import com.huskerdev.openglfx.*
+import com.huskerdev.openglfx.GLExecutor.Companion.glActiveTexture
 import com.huskerdev.openglfx.GLExecutor.Companion.glGetInteger
-import com.huskerdev.openglfx.GLFXInfo
-import com.huskerdev.openglfx.GL_TEXTURE_BINDING_2D
 import com.huskerdev.openglfx.internal.platforms.win.D3D9
 import com.sun.javafx.tk.Toolkit
 import com.sun.prism.Graphics
@@ -105,7 +105,13 @@ class GLFXUtils {
 
         fun fetchGLTexId(texture: Texture, g: Graphics): Int{
             g.drawTexture(texture, 0f, 0f, 0f, 0f)
-            return glGetInteger(GL_TEXTURE_BINDING_2D)
+            val oldActiveTexture = glGetInteger(GL_ACTIVE_TEXTURE)
+            glActiveTexture(GL_TEXTURE0)
+            val textureId = glGetInteger(GL_TEXTURE_BINDING_2D)
+            if (oldActiveTexture != GL_TEXTURE_2D) {
+                glActiveTexture(oldActiveTexture)
+            }
+            return textureId
         }
 
         fun fetchDXTexHandle(texture: Texture, g: Graphics): Long{

--- a/modules/core/kotlin/com/huskerdev/openglfx/internal/canvas/IOSurfaceCanvas.kt
+++ b/modules/core/kotlin/com/huskerdev/openglfx/internal/canvas/IOSurfaceCanvas.kt
@@ -4,6 +4,8 @@ import com.huskerdev.grapl.gl.GLProfile
 import com.huskerdev.openglfx.*
 import com.huskerdev.openglfx.GLExecutor.Companion.glDisable
 import com.huskerdev.openglfx.GLExecutor.Companion.glEnable
+import com.huskerdev.openglfx.GLExecutor.Companion.glGetInteger
+import com.huskerdev.openglfx.GL_SCISSOR_TEST
 import com.huskerdev.openglfx.GL_TEXTURE_RECTANGLE
 import com.huskerdev.openglfx.canvas.GLCanvas
 import com.huskerdev.openglfx.internal.Framebuffer
@@ -86,9 +88,13 @@ open class IOSurfaceCanvas(
             }
 
             ioSurface.lock()
+
+            val scissorTestEnabled = glGetInteger(GL_SCISSOR_TEST) != 0
             glDisable(GL_SCISSOR_TEST)
             fxInteropFBO.blitTo(fxTextureFBO)
-            glEnable(GL_SCISSOR_TEST)
+            if (scissorTestEnabled) {
+                glEnable(GL_SCISSOR_TEST)
+            }
             ioSurface.unlock()
 
             return fxTexture

--- a/modules/core/kotlin/com/huskerdev/openglfx/internal/platforms/macos/IOSurface.kt
+++ b/modules/core/kotlin/com/huskerdev/openglfx/internal/platforms/macos/IOSurface.kt
@@ -1,8 +1,10 @@
 package com.huskerdev.openglfx.internal.platforms.macos
 
 import com.huskerdev.grapl.gl.GLContext
+import com.huskerdev.openglfx.*
 import com.huskerdev.openglfx.GLExecutor.Companion.glBindTexture
 import com.huskerdev.openglfx.GLExecutor.Companion.glGenTextures
+import com.huskerdev.openglfx.GLExecutor.Companion.glGetInteger
 import com.huskerdev.openglfx.GL_BGRA
 import com.huskerdev.openglfx.GL_RGBA
 import com.huskerdev.openglfx.GL_TEXTURE_RECTANGLE
@@ -24,6 +26,7 @@ internal class IOSurface(val width: Int, val height: Int) {
     private val handle = nCreateIOSurface(width, height)
 
     fun createBoundTexture(): Int {
+        val oldTexture = glGetInteger(GL_TEXTURE_BINDING_2D)
         val texture = glGenTextures()
         glBindTexture(GL_TEXTURE_RECTANGLE, texture)
         nCGLTexImageIOSurface2D(
@@ -34,6 +37,7 @@ internal class IOSurface(val width: Int, val height: Int) {
             GL_BGRA,
             GL_UNSIGNED_INT_8_8_8_8_REV,
             handle, 0)
+        glBindTexture(GL_TEXTURE_BINDING_2D, oldTexture)
         return texture
     }
 

--- a/modules/core/native/shared/executor.cpp
+++ b/modules/core/native/shared/executor.cpp
@@ -4,6 +4,7 @@
 
 
 jni_gl(void, nInitGLFunctions)(JNIEnv* env, jobject) {
+    a_glActiveTexture = (glActiveTexturePtr)a_GetProcAddress("glActiveTexture");
     a_glEnable = (glEnablePtr)a_GetProcAddress("glEnable");
     a_glDisable = (glDisablePtr)a_GetProcAddress("glDisable");
     a_glViewport = (glViewportPtr)a_GetProcAddress("glViewport");
@@ -54,6 +55,10 @@ jni_gl(void, nInitGLFunctions)(JNIEnv* env, jobject) {
     a_glEnableVertexAttribArray = (glEnableVertexAttribArrayPtr)a_GetProcAddress("glEnableVertexAttribArray");
     a_glDeleteBuffers = (glDeleteBuffersPtr)a_GetProcAddress("glDeleteBuffers");
     a_glDrawArrays = (glDrawArraysPtr)a_GetProcAddress("glDrawArrays");
+}
+
+jni_gl(void, glActiveTexture)(JNIEnv* env, jobject, jint unit) {
+    a_glActiveTexture(unit);
 }
 
 jni_gl(void, glEnable)(JNIEnv* env, jobject, jint cap) {

--- a/modules/core/native/shared/openglfx.h
+++ b/modules/core/native/shared/openglfx.h
@@ -94,7 +94,7 @@ static void* a_GetProcAddress(const char* name) {
 #endif
 }
 
-
+typedef void (*glActiveTexturePtr)(GLenum unit);
 typedef void (*glEnablePtr)(GLint cap);
 typedef void (*glDisablePtr)(GLint cap);
 typedef void (*glDeleteFramebuffersPtr)(GLsizei n, const GLuint* framebuffers);
@@ -146,6 +146,7 @@ typedef void (*glDeleteBuffersPtr)(GLsizei n, const GLuint *buffers);
 typedef void (*glDrawArraysPtr)(GLenum mode, GLint first, GLsizei count);
 
 
+static glActiveTexturePtr               a_glActiveTexture;
 static glEnablePtr                      a_glEnable;
 static glDisablePtr                     a_glDisable;
 static glViewportPtr                    a_glViewport;


### PR DESCRIPTION
This PR fixes some IOSurface bugs on MacOS.
- The fetchGLTexId  method did not work when JavaFX activated another texture unit. 
- Restores the state of the SCISSOR_TEST and restores the active texture