### PR TITLE
Downgrade linux build environment to ubuntu-22.04

### DIFF
--- a/.github/workflows/maven_publish.yml
+++ b/.github/workflows/maven_publish.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Downgrade linux build environment to ubuntu-22.04 to increase compatibility with more linux distribution. 
Currently it is not possible to use openglfx on RHEL 9 systems. This is related to the required c++ std lib.